### PR TITLE
Enable running of continuous and add in timing information

### DIFF
--- a/getbno055.c
+++ b/getbno055.c
@@ -40,7 +40,7 @@ char calfile[256];
  * print_usage() prints the programs commandline instructions.  *
  * ------------------------------------------------------------ */
 void usage() {
-   static char const usage[] = "Usage: getbno055 [-a hex i2c-addr] [-m <opr_mode>] [-t acc|gyr|mag|eul|qua|lin|gra|inf|cal] [-r] [-w calfile] [-l calfile] [-o htmlfile] [-v]\n\
+   static char const usage[] = "Usage: getbno055 [-a hex i2c-addr] [-m <opr_mode>] [-t acc|gyr|mag|eul|qua|lin|gra|inf|cal|con] [-r] [-w calfile] [-l calfile] [-o htmlfile] [-v]\n\
 \n\
 Command line parameters have the following format:\n\
    -a   sensor I2C bus address in hex, Example: -a 0x28 (default)\n\
@@ -75,7 +75,7 @@ Command line parameters have the following format:\n\
            lin = Linear Accel (X-Y-Z axis values)\n\
            inf = Sensor info (23 version and state values)\n\
            cal = Calibration data (mag, gyro and accel calibration values)\n\
-           continuous = continuous data-eul)\n\
+           con = Continuous data (eul)\n\
    -l   load sensor calibration data from file, Example -l ./bno055.cal\n\
    -w   write sensor calibration data to file, Example -w ./bno055.cal\n\
    -o   output sensor data to HTML table file, requires -t, Example: -o ./bno055.html\n\
@@ -738,10 +738,10 @@ int main(int argc, char *argv[]) {
    } /* End reading Euler Orientation */
 
   /* ----------------------------------------------------------- *
-    *  "-t continuous"                                            *
+    *  "-t con"                                                   *
     * This requires the sensor to be in fusion mode (mode > 7).   *
     * ----------------------------------------------------------- */
-   if(strcmp(datatype, "continuous") == 0) {
+   if(strcmp(datatype, "con") == 0) {
 
       int mode = get_mode();
       if(mode < 8) {

--- a/getbno055.c
+++ b/getbno055.c
@@ -755,7 +755,7 @@ int main(int argc, char *argv[]) {
        * EUL 66.06 -3.00 -15.56 (EUL H R P in Degrees)               *
        * ----------------------------------------------------------- */
       while(1){
-	clock_t t;
+        clock_t t;
         t = clock();
 
         res = get_eul(&bnod);
@@ -785,7 +785,7 @@ int main(int argc, char *argv[]) {
          fclose(html);
         }
 
-	t = clock() - t;
+        t = clock() - t;
         double time_taken = ((double)t)/CLOCKS_PER_SEC; // in seconds
         printf("Sensor reading took %f seconds \n", time_taken);
       }

--- a/getbno055.c
+++ b/getbno055.c
@@ -755,13 +755,17 @@ int main(int argc, char *argv[]) {
        * EUL 66.06 -3.00 -15.56 (EUL H R P in Degrees)               *
        * ----------------------------------------------------------- */
       while(1){
+	clock_t t;
+        t = clock();
+
         res = get_eul(&bnod);
         if(res != 0) {
            printf("Error: Cannot read Euler orientation data.\n");
            continue;
         }
+
         printf("EUL %3.4f %3.4f %3.4f\n", bnod.eul_head, bnod.eul_roll, bnod.eul_pitc);
-        sleep(1);
+
         if(outflag == 1) {
          /* -------------------------------------------------------- *
           *  Open the html file for writing Euler Orientation data   *
@@ -780,6 +784,10 @@ int main(int argc, char *argv[]) {
          fprintf(html, "</tr></table>\n");
          fclose(html);
         }
+
+	t = clock() - t;
+        double time_taken = ((double)t)/CLOCKS_PER_SEC; // in seconds
+        printf("Sensor reading took %f seconds \n", time_taken);
       }
       
    } /* End reading continuous data */


### PR DESCRIPTION
When running continuous data, an error is displayed.
```
$ ./getbno055 -t continuous
Error: Cannot get valid -t data type argument.
```
This is caused by a requirement that all optargs that follow '-t' be 3 letters long, but 'continuous' is obviously longer.  This is an easy fix.  This PR also adds timing information to see how long it takes to cycle the while loop.

```
$ ./getbno055 -t con
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000086 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000095 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000100 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000099 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000081 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000113 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000116 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000124 seconds 
EUL 283.3750 19.6875 -35.1250
Sensor reading took 0.000117 seconds
```

This is really what I was after - the loop is taking around 2ms on my RPi4. I don't quite understand why the famous clock-stretching bug is not affecting performance.  
